### PR TITLE
refactor: Update DefaultApiEndpoint and fix URL handling in fetchClientAppId

### DIFF
--- a/client.go
+++ b/client.go
@@ -2,6 +2,7 @@ package sdk
 
 import (
 	"context"
+	"strings"
 
 	gql "github.com/Khan/genqlient/graphql"
 
@@ -39,7 +40,14 @@ func NewClient(ctx context.Context, domain, user, secret string, ops ...func(opt
 		op(&options)
 	}
 
-	client := gql.NewClient(options.UrlOverride+internal.GqlApiPath, &internal.AuthedDoer{
+	url := options.UrlOverride
+	if !strings.HasSuffix(url, "/") {
+		url += "/"
+	}
+
+	url += internal.GqlApiPath
+
+	client := gql.NewClient(url, &internal.AuthedDoer{
 		Domain: domain,
 		User:   user,
 		Secret: secret,

--- a/internal/auth.go
+++ b/internal/auth.go
@@ -192,7 +192,7 @@ func fetchClientAppId(urlBase, domain string) (string, error) {
 	}
 
 	if !strings.HasSuffix(urlBase, "/") {
-		urlBase = urlBase + "/"
+		urlBase += "/"
 	}
 
 	url := urlBase + "admin/org/" + domain

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -1,6 +1,6 @@
 package internal
 
-const DefaultApiEndpoint = "https://api.raito.cloud"
-const GqlApiPath = "/query"
+const DefaultApiEndpoint = "https://api.raito.cloud/"
+const GqlApiPath = "query"
 
 const MaxPageSize = 25


### PR DESCRIPTION
- Update DefaultApiEndpoint to include a trailing slash for consistency.
- Adjust URL handling in fetchClientAppId to ensure correct formatting.